### PR TITLE
add support for macos and addl safeguards

### DIFF
--- a/ConvertAll.py
+++ b/ConvertAll.py
@@ -1,62 +1,133 @@
 #%% Convert a Folder of PowerPoint PPTs to PDFs
 
-# Purpose: Converts all PowerPoint PPTs in a folder to Adobe PDF
+# Purpose: Converts all PowerPoint PPT/PPTX files in a folder to PDF
+# Author:  Matthew Renze (improvements: reuse app, cleanup, cross-platform fallback)
 
-# Author:  Matthew Renze
+# Usage:   python ConvertAll.py input-folder [output-folder]
+#   - input-folder  = folder containing the PowerPoint files to convert
+#   - output-folder = optional; defaults to same as input-folder
 
-# Usage:   python.exe ConvertAll.py input-folder output-folder
-#   - input-folder = the folder containing the PowerPoint files to be converted
-#   - output-folder = the folder where the Adobe PDFs will be created
+# Example: python ConvertAll.py .
+# Example: python ConvertAll.py ./slides ./pdfs
 
-# Example: python.exe ConvertAll.py C:\InputFolder C:\OutputFolder
+# Note: On Windows with PowerPoint installed, uses COM. On macOS/Linux, uses LibreOffice if available.
 
-# Note: Also works with PPTX file format
-
-#%% Import libraries
 import sys
 import os
-import comtypes.client
+import subprocess
+import shutil
 
-#%% Get console arguments
-input_folder_path = sys.argv[1]
-output_folder_path = sys.argv[2]
+def convert_with_libreoffice(input_folder: str, output_folder: str) -> bool:
+    """Convert PPT/PPTX to PDF using LibreOffice (macOS/Linux). Returns True if any file was converted."""
+    # Common locations for soffice
+    candidates = [
+        "/Applications/LibreOffice.app/Contents/MacOS/soffice",  # macOS
+        shutil.which("soffice"),
+        shutil.which("libreoffice"),
+    ]
+    soffice = None
+    for c in candidates:
+        if c and os.path.isfile(c):
+            soffice = c
+            break
+    if not soffice:
+        return False
 
-#%% Convert folder paths to Windows format
-input_folder_path = os.path.abspath(input_folder_path)
-output_folder_path = os.path.abspath(output_folder_path)
+    input_folder = os.path.abspath(input_folder)
+    output_folder = os.path.abspath(output_folder)
+    os.makedirs(output_folder, exist_ok=True)
 
-#%% Get files in input folder
-input_file_paths = os.listdir(input_folder_path)
+    exts = (".ppt", ".pptx")
+    files = [f for f in os.listdir(input_folder)
+             if os.path.isfile(os.path.join(input_folder, f)) and f.lower().endswith(exts)]
+    if not files:
+        return True  # nothing to do
 
-#%% Convert each file
-for input_file_name in input_file_paths:
+    # LibreOffice --convert-to pdf --outdir <dir> file1 file2 ...
+    cmd = [soffice, "--headless", "--convert-to", "pdf", "--outdir", output_folder]
+    cmd.extend([os.path.join(input_folder, f) for f in files])
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, timeout=300)
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return True
 
-    # Skip if file does not contain a power point extension
-    if not input_file_name.lower().endswith((".ppt", ".pptx")):
-        continue
-    
-    # Create input file path
-    input_file_path = os.path.join(input_folder_path, input_file_name)
-        
-    # Create powerpoint application object
-    powerpoint = comtypes.client.CreateObject("Powerpoint.Application")
-    
-    # Set visibility to minimize
-    powerpoint.Visible = 1
-    
-    # Open the powerpoint slides
-    slides = powerpoint.Presentations.Open(input_file_path)
-    
-    # Get base file name
-    file_name = os.path.splitext(input_file_name)[0]
-    
-    # Create output file path
-    output_file_path = os.path.join(output_folder_path, file_name + ".pdf")
-    
-    # Save as PDF (formatType = 32)
-    slides.SaveAs(output_file_path, 32)
-    
-    # Close the slide deck
-    slides.Close()
-    
-    
+
+def convert_with_powerpoint_com(input_folder: str, output_folder: str) -> None:
+    """Convert PPT/PPTX to PDF using Windows COM + Microsoft PowerPoint."""
+    import comtypes.client
+
+    input_folder = os.path.abspath(input_folder)
+    output_folder = os.path.abspath(output_folder)
+    os.makedirs(output_folder, exist_ok=True)
+
+    entries = os.listdir(input_folder)
+    files = [f for f in entries
+             if os.path.isfile(os.path.join(input_folder, f))
+             and f.lower().endswith((".ppt", ".pptx"))]
+    if not files:
+        print("No PPT/PPTX files found in", input_folder)
+        return
+
+    powerpoint = None
+    try:
+        powerpoint = comtypes.client.CreateObject("Powerpoint.Application")
+        powerpoint.Visible = 1
+        for input_file_name in files:
+            input_file_path = os.path.join(input_folder, input_file_name)
+            output_name = os.path.splitext(input_file_name)[0] + ".pdf"
+            output_file_path = os.path.join(output_folder, output_name)
+            try:
+                slides = powerpoint.Presentations.Open(input_file_path)
+                slides.SaveAs(output_file_path, 32)  # 32 = ppSaveAsPDF
+                slides.Close()
+                print("Converted:", input_file_name, "->", output_name)
+            except Exception as e:
+                print("Error converting", input_file_name, ":", e)
+    finally:
+        if powerpoint is not None:
+            try:
+                powerpoint.Quit()
+            except Exception:
+                pass
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python ConvertAll.py input-folder [output-folder]")
+        print("Example: python ConvertAll.py .")
+        sys.exit(1)
+
+    input_folder = sys.argv[1]
+    output_folder = sys.argv[2] if len(sys.argv) > 2 else input_folder
+
+    if not os.path.isdir(input_folder):
+        print("Error: input folder does not exist:", input_folder)
+        sys.exit(1)
+
+    if sys.platform == "win32":
+        try:
+            convert_with_powerpoint_com(input_folder, output_folder)
+            return
+        except ImportError:
+            print("comtypes not installed. Install with: pip install comtypes")
+            sys.exit(1)
+
+    # macOS / Linux: try LibreOffice first
+    exts = (".ppt", ".pptx")
+    root = os.path.abspath(input_folder)
+    files = [f for f in os.listdir(input_folder)
+             if os.path.isfile(os.path.join(input_folder, f)) and f.lower().endswith(exts)]
+    if not files:
+        print("No PPT/PPTX files found in", root)
+        return
+    if convert_with_libreoffice(input_folder, output_folder):
+        print("Converted", len(files), "file(s) with LibreOffice. Output folder:", os.path.abspath(output_folder))
+        return
+    print("LibreOffice not found. On macOS install with: brew install --cask libreoffice")
+    print("On Windows run this script with PowerPoint installed and comtypes: pip install comtypes")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -1,9 +1,47 @@
 # PowerPoint to PDF
 
-A set of Python scripts to convert PowerPoint (PPT/PPTX) files to Adobe PDF
+A set of Python scripts to convert PowerPoint (PPT/PPTX) files to PDF.
 
-- Convert.py - Converts a PowerPoint (PPT/PPTX) file into an Adobe PDF
-- ConvertAll.py - Converts all PowerPoint (PPT/PPTX) files in a folder into Adobe PDFs
-- ConvertHere.py - Converts all PowerPoint (PPT/PPTX) files the working folder into Adobe PDFs
+- **Convert.py** – Converts a single PowerPoint (PPT/PPTX) file to PDF
+- **ConvertAll.py** – Converts all PowerPoint (PPT/PPTX) files in a folder to PDFs
+- **ConvertHere.py** – Converts all PowerPoint (PPT/PPTX) files in the script’s folder to PDFs (Windows COM only)
 
-Please see each script for full instructions on how to use the script.
+## Quick start: convert all PPTX in current directory
+
+```bash
+python ConvertAll.py .
+```
+
+Output PDFs are written to the same folder. To use a different output folder:
+
+```bash
+python ConvertAll.py . ./pdfs
+```
+
+## Platform requirements
+
+| Platform | Engine | Requirements |
+|----------|--------|--------------|
+| **Windows** | Microsoft PowerPoint (COM) | PowerPoint installed, `pip install comtypes` |
+| **macOS** | LibreOffice | `brew install --cask libreoffice` |
+| **Linux** | LibreOffice | Install `libreoffice` (e.g. `apt install libreoffice`) |
+
+On Windows, run from a folder with PPT/PPTX files or pass input (and optional output) folder. On macOS/Linux, LibreOffice is used automatically when available.
+
+## Improvements made to ConvertAll.py
+
+- **Single PowerPoint instance (Windows)** – One COM application is created and reused for all files, then closed with `Quit()` to avoid leaving PowerPoint running.
+- **Skip non-files** – Only regular files with `.ppt`/`.pptx` are converted; directories and other entries are ignored.
+- **Output folder validation** – Input folder must exist; output folder is created if missing.
+- **Optional output folder** – Second argument is optional; default is the same as the input folder.
+- **Cross-platform** – On macOS/Linux, uses LibreOffice headless when available so the script runs without Windows or PowerPoint.
+- **Clear errors** – Usage message when no arguments given; explicit messages when LibreOffice or comtypes are missing.
+- **Cleanup** – `try/finally` ensures PowerPoint is quit even if a conversion fails.
+
+## Requirements (Windows only)
+
+```bash
+pip install -r requirements.txt
+```
+
+(`comtypes` is only needed on Windows for the PowerPoint COM path.)


### PR DESCRIPTION
## Suggested improvements

- **One PowerPoint instance** – Create it once, convert all files, then close it. Don’t start a new instance per file or leave it running.
- **Only convert real files** – Ignore folders and anything that isn’t a `.ppt` or `.pptx` file.
- **Always close PowerPoint** – Use a `try/finally` so PowerPoint is closed even when a conversion fails.
- **Optional output folder** – Allow `python ConvertAll.py .` (current folder only). Second argument = output folder, optional.
- **Check input folder** – Make sure the input path exists and is a folder before converting.
- **Support Mac/Linux** – If not on Windows, use LibreOffice (`soffice --headless --convert-to pdf`) when it’s installed.
- **Clear errors** – Print usage when no arguments are given; say clearly when LibreOffice or comtypes are missing.
- **Per-file errors** – If one file fails, log it and continue with the rest instead of stopping the whole run.